### PR TITLE
Fix: Add sleep delay to uinput ENTER sequence for reliability

### DIFF
--- a/sirfidal_auto_send_enter_at_login.py
+++ b/sirfidal_auto_send_enter_at_login.py
@@ -143,7 +143,7 @@ def main():
           # Has the number of active UIDs increased?
           if chg > 0:
 
-            Find out the active virtual console
+            # Find out the active virtual console
             vc = active_vc()
             if not vc:
               print("Error determining the active virtual console")
@@ -161,13 +161,13 @@ def main():
                 continue
 
               try:
-                sleep(.5)   # Pause before typing to let GUI catch up
+                sleep(.2)   # Pause before typing to let GUI catch up
                 ui.write(ecodes.EV_KEY, ecodes.KEY_ENTER, 1)
                 ui.syn()
-                sleep(.2)   # Pause needed for gdm
+                sleep(.1)   # Pause needed for gdm
                 ui.write(ecodes.EV_KEY, ecodes.KEY_ENTER, 0)
                 ui.syn()
-                sleep(.2)   # Pause needed for gdm
+                sleep(.1)   # Pause needed for gdm
                 print("ENTER sent to console {}".format(vc))
               except Exception as e:
                 print("UInput write error: {}".format(e))

--- a/sirfidal_auto_send_enter_at_login.py
+++ b/sirfidal_auto_send_enter_at_login.py
@@ -161,13 +161,13 @@ def main():
                 continue
 
               try:
-                sleep(.2)   # Pause before typing to let GUI catch up
+                sleep(.5)   # Pause before typing to let GUI catch up
                 ui.write(ecodes.EV_KEY, ecodes.KEY_ENTER, 1)
                 ui.syn()
-                sleep(.1)   # Pause needed for gdm
+                sleep(.2)   # Pause needed for gdm
                 ui.write(ecodes.EV_KEY, ecodes.KEY_ENTER, 0)
                 ui.syn()
-                sleep(.1)   # Pause needed for gdm
+                sleep(.2)   # Pause needed for gdm
                 print("ENTER sent to console {}".format(vc))
               except Exception as e:
                 print("UInput write error: {}".format(e))

--- a/sirfidal_auto_send_enter_at_login.py
+++ b/sirfidal_auto_send_enter_at_login.py
@@ -143,11 +143,11 @@ def main():
           # Has the number of active UIDs increased?
           if chg > 0:
 
-            # Find out the active virtual console
-            # vc = active_vc()
-            # if not vc:
-            #   print("Error determining the active virtual console")
-            #   continue
+            Find out the active virtual console
+            vc = active_vc()
+            if not vc:
+              print("Error determining the active virtual console")
+              continue
 
             # If no session is running on the active virtual console, or a
             # greeter session is running, send the keystroke sequence for

--- a/sirfidal_auto_send_enter_at_login.py
+++ b/sirfidal_auto_send_enter_at_login.py
@@ -161,7 +161,7 @@ def main():
                 continue
 
               try:
-                sleep(.2)   # Pause before typing to let GUI catch up
+                sleep(.1)   # Pause before typing to let GUI catch up
                 ui.write(ecodes.EV_KEY, ecodes.KEY_ENTER, 1)
                 ui.syn()
                 sleep(.1)   # Pause needed for gdm

--- a/sirfidal_auto_send_enter_at_login.py
+++ b/sirfidal_auto_send_enter_at_login.py
@@ -144,10 +144,10 @@ def main():
           if chg > 0:
 
             # Find out the active virtual console
-            vc = active_vc()
-            if not vc:
-              print("Error determining the active virtual console")
-              continue
+            # vc = active_vc()
+            # if not vc:
+            #   print("Error determining the active virtual console")
+            #   continue
 
             # If no session is running on the active virtual console, or a
             # greeter session is running, send the keystroke sequence for

--- a/sirfidal_auto_send_enter_at_login.py
+++ b/sirfidal_auto_send_enter_at_login.py
@@ -161,6 +161,7 @@ def main():
                 continue
 
               try:
+                sleep(.2)   # Pause before typing to let GUI catch up
                 ui.write(ecodes.EV_KEY, ecodes.KEY_ENTER, 1)
                 ui.syn()
                 sleep(.1)   # Pause needed for gdm


### PR DESCRIPTION
**Problem:**
The display manager often misses the keypress event, and we are stuck at password prompt.

**Solution:**
Added `sleep(.1)` between the key press (`1`) and key release (`0`) events.

**Tested on:**
- Hardware: Symcod TermiCom W156M (Industrial Touchscreen)
- OS: Ubuntu 22.04 with LightDM (works with gdm too)
